### PR TITLE
Bump highlight.js to 9.7.0

### DIFF
--- a/lib/marked-html.js
+++ b/lib/marked-html.js
@@ -121,7 +121,7 @@ exports.get_argv = function() {
 
         .string('css_hljs_theme')
         .describe('css_hljs_theme', 'Default template option: URL of highlight.js CSS theme to use')
-        .default('css_hljs_theme', 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/xcode.min.css')
+        .default('css_hljs_theme', 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.7.0/styles/xcode.min.css')
 
         .argv;
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mustache": "2.2.x",
     "marked": "0.3.x",
     "optimist": "0.6.x",
-    "highlight.js": "9.0.x"
+    "highlight.js": "9.7.x"
   },
   "devDependencies": {
     "mocha": "2.3.x",


### PR DESCRIPTION
I was testing to see if highlight.js had improved support for rendering code on mobile sites, and tried out a more recent version of the module, and thought I'd commit the version bump back.

I ran `npm run test` where everything passed.

Thanks for the module.